### PR TITLE
Fix Sentinel conditional check in UserIdentificationTrait

### DIFF
--- a/src/Stevebauman/Inventory/Traits/UserIdentificationTrait.php
+++ b/src/Stevebauman/Inventory/Traits/UserIdentificationTrait.php
@@ -34,7 +34,7 @@ trait UserIdentificationTrait
          */
         try
         {
-            if(class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') || $class = class_exists('\Cartalyst\Sentinel\Laravel\Facades\Sentinel'))
+            if(class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel'))
             {
                 if($class::check()) return $class::getUser()->id;
 


### PR DESCRIPTION
Without this change if an app is using Sentinel instead of Sentry, an exception is thrown because the $class variable was a boolean returned from class_exists instead of the actual class.