### PR TITLE
Remove $this->skusEnabled() from the getSku() method of InventoryTrait.

### DIFF
--- a/src/Stevebauman/Inventory/Traits/InventoryTrait.php
+++ b/src/Stevebauman/Inventory/Traits/InventoryTrait.php
@@ -517,7 +517,7 @@ trait InventoryTrait
      */
     public function getSku()
     {
-        if($this->skusEnabled() && $this->hasSku()) return $this->sku->code;
+        if($this->hasSku()) return $this->sku->code;
 
         return NULL;
     }


### PR DESCRIPTION
If sku auto-generation is turned off trying to call $this->sku_code will no longer work with the skusEnabled() check in getSku(). Since you can still utilize, create and update sku's when the auto-generation is turned off, this check basically nullifies the $this->sku_code shortcut, and instead forces the dev to change the call to $this->sku->code instead. Removing the check just allows the shortcut to remain in place whether auto-generation is enabled or disabled.