### PR TITLE
metric_id is not nullable

### DIFF
--- a/src/Migrations/2014_07_31_123213_create_inventory_tables.php
+++ b/src/Migrations/2014_07_31_123213_create_inventory_tables.php
@@ -17,7 +17,7 @@ class CreateInventoryTables extends Migration
 
             $table->integer('category_id')->unsigned()->nullable();
             $table->integer('user_id')->unsigned()->nullable();
-            $table->integer('metric_id')->unsigned();
+            $table->integer('metric_id')->unsigned()->nullable();
             $table->string('name');
             $table->text('description')->nullable();
 


### PR DESCRIPTION
Inventory model has hasMetric() function, but metric_id is not nullable. Metric Id is not necessary in inventory which has assemblies and is not being assembly, right?